### PR TITLE
1.4.2

### DIFF
--- a/app/lib/writers_base/installer.rb
+++ b/app/lib/writers_base/installer.rb
@@ -22,6 +22,7 @@ module WritersBase
     end
 
     def install
+      uninstall
       periods.each do |period|
         entries(period).each do |tool|
           path = dest(period, tool)

--- a/app/lib/writers_base/tool/access_log_compress_tool.rb
+++ b/app/lib/writers_base/tool/access_log_compress_tool.rb
@@ -15,7 +15,7 @@ module WritersBase
     end
 
     def description
-      return "#{dir}の#{days}日経過したログファイルを、gzip圧縮します。"
+      return "#{dir}の#{days}日経過したログファイルを、zstd圧縮します。"
     end
 
     private

--- a/app/lib/writers_base/tool/mysql_dump_tool.rb
+++ b/app/lib/writers_base/tool/mysql_dump_tool.rb
@@ -30,7 +30,7 @@ module WritersBase
         '-u', params[:user],
         '--port', params[:port],
         params[:db],
-        :|, 'gzip',
+        :|, 'zstd', "-#{config['/zstd/level']}",
         :>, path
       ])
       command.env = {'MYSQL_PWD' => params[:password]}
@@ -56,13 +56,13 @@ module WritersBase
     def finder(dir)
       finder = Ginseng::FileFinder.new
       finder.dir = dir
-      finder.patterns = ['*.sql.gz']
+      finder.patterns = ['*.sql.zst', '*.sql.gz']
       finder.mtime = days
       return finder
     end
 
     def dump_path(db, dir)
-      return File.join(dir, "#{db}_#{Time.now.strftime('%Y-%m-%d')}.sql.gz")
+      return File.join(dir, "#{db}_#{Time.now.strftime('%Y-%m-%d')}.sql.zst")
     end
 
     def dest_dir

--- a/app/lib/writers_base/tool/postgresql_dump_tool.rb
+++ b/app/lib/writers_base/tool/postgresql_dump_tool.rb
@@ -30,7 +30,7 @@ module WritersBase
         '-U', params[:user],
         '-p', params[:port],
         '-d', params[:db],
-        :|, 'gzip',
+        :|, 'zstd', "-#{config['/zstd/level']}",
         :>, path
       ])
       command.env = {'PGPASSWORD' => params[:password]}
@@ -56,13 +56,13 @@ module WritersBase
     def finder(dir)
       finder = Ginseng::FileFinder.new
       finder.dir = dir
-      finder.patterns = ['*.sql.gz']
+      finder.patterns = ['*.sql.zst', '*.sql.gz']
       finder.mtime = days
       return finder
     end
 
     def dump_path(db, dir)
-      return File.join(dir, "#{db}_#{Time.now.strftime('%Y-%m-%d')}.sql.gz")
+      return File.join(dir, "#{db}_#{Time.now.strftime('%Y-%m-%d')}.sql.zst")
     end
 
     def dest_dir

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -19,9 +19,8 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/THE-POWERNEWS/writersbase-tools
-  version: 1.4.1
+  version: 1.4.2
 ruby:
-  jit: false
   bin: /usr/bin/ruby3.3
 hourly: []
 daily: []
@@ -77,7 +76,6 @@ rsync_backup:
   sources:
     - /etc
     - /usr/local/etc
-    - /home/mastodon/repos/mastodon
   excludes:
     - .git
     - .zfs


### PR DESCRIPTION
- ダンプツール(mysql/postgresql)の圧縮をgzipからzstdに変更
- 旧.gz形式も削除対象として維持
- access_log_compress_toolの説明文をzstdに修正
- installerでinstall時に旧スクリプトをuninstallするよう修正
- 未使用のjit設定を削除
- rsync_backupのデフォルトsourcesからMastodonフォルダを除外