### PR TITLE
fix: Mastodonツールのchdir・エラーハンドリング修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: c066e8e801783bbb4240d97d660bdd889c652fa0
+  revision: 007cc8ecceb2c7a7b4348f13264abe7ac6ab59cb
   specs:
-    ginseng-core (1.15.11)
+    ginseng-core (1.15.12)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.8.0)
       cgi (>= 0.4.2)
@@ -232,4 +232,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-  4.0.6
+  4.0.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,4 +232,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-  4.0.4
+  4.0.6

--- a/app/lib/writers_base/tool/mastodon_follow_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_follow_tool.rb
@@ -24,7 +24,10 @@ module WritersBase
       )
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
-      command.exec unless test?
+      unless test?
+        command.exec
+        raise command.stderr if command.status.nonzero?
+      end
       return command
     end
 

--- a/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
@@ -26,7 +26,10 @@ module WritersBase
       )
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
-      command.exec unless test?
+      unless test?
+        command.exec
+        raise command.stderr if command.status.nonzero?
+      end
       return command
     end
 

--- a/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
@@ -26,7 +26,10 @@ module WritersBase
       )
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
-      command.exec unless test?
+      unless test?
+        command.exec
+        raise command.stderr if command.status.nonzero?
+      end
       return command
     end
 

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -19,7 +19,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/THE-POWERNEWS/writersbase-tools
-  version: 1.4.6
+  version: 1.4.7
 ruby:
   bin: /usr/bin/ruby3.3
 hourly: []


### PR DESCRIPTION
## Summary
- ginseng-coreのCommandLineでchdirオプションを使用するよう修正（v1.15.12）
- Mastodonツールでtootctlが非ゼロステータスを返した場合にエラーとして処理

## Test plan
- [ ] サーバーで`bundle update ginseng-core`を実行
- [ ] Mastodonツール（mastodon_follow, mastodon_maintenance, mastodon_media_cleanup）の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)