### PR TITLE
fix: MastodonツールのRAILS_ENV受け渡し修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 007cc8ecceb2c7a7b4348f13264abe7ac6ab59cb
+  revision: 80891c47bdca2915b44b1aeb5546189fa1e5bdef
   specs:
-    ginseng-core (1.15.12)
+    ginseng-core (1.15.13)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.8.0)
       cgi (>= 0.4.2)

--- a/app/lib/writers_base/tool/mastodon_follow_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_follow_tool.rb
@@ -19,9 +19,7 @@ module WritersBase
     private
 
     def tootctl_command(args)
-      command = CommandLine.new(
-        ['bundle', 'exec', 'bin/tootctl', *args],
-      )
+      command = CommandLine.new(['bundle', 'exec', 'bin/tootctl', *args])
       command.user = mastodon_user
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir

--- a/app/lib/writers_base/tool/mastodon_follow_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_follow_tool.rb
@@ -20,8 +20,9 @@ module WritersBase
 
     def tootctl_command(args)
       command = CommandLine.new(
-        ['sudo', '-u', mastodon_user, 'bundle', 'exec', 'bin/tootctl', *args],
+        ['bundle', 'exec', 'bin/tootctl', *args],
       )
+      command.user = mastodon_user
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
       unless test?

--- a/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
@@ -21,9 +21,7 @@ module WritersBase
     private
 
     def tootctl_command(args)
-      command = CommandLine.new(
-        ['bundle', 'exec', 'bin/tootctl', *args],
-      )
+      command = CommandLine.new(['bundle', 'exec', 'bin/tootctl', *args])
       command.user = mastodon_user
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir

--- a/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
@@ -22,8 +22,9 @@ module WritersBase
 
     def tootctl_command(args)
       command = CommandLine.new(
-        ['sudo', '-u', mastodon_user, 'bundle', 'exec', 'bin/tootctl', *args],
+        ['bundle', 'exec', 'bin/tootctl', *args],
       )
+      command.user = mastodon_user
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
       unless test?

--- a/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
@@ -21,9 +21,7 @@ module WritersBase
     private
 
     def tootctl_command(args)
-      command = CommandLine.new(
-        ['bundle', 'exec', 'bin/tootctl', *args],
-      )
+      command = CommandLine.new(['bundle', 'exec', 'bin/tootctl', *args])
       command.user = mastodon_user
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir

--- a/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
@@ -22,8 +22,9 @@ module WritersBase
 
     def tootctl_command(args)
       command = CommandLine.new(
-        ['sudo', '-u', mastodon_user, 'bundle', 'exec', 'bin/tootctl', *args],
+        ['bundle', 'exec', 'bin/tootctl', *args],
       )
+      command.user = mastodon_user
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
       unless test?

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -19,7 +19,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/THE-POWERNEWS/writersbase-tools
-  version: 1.4.7
+  version: 1.4.8
 ruby:
   bin: /usr/bin/ruby3.3
 hourly: []


### PR DESCRIPTION
## Summary
- MastodonツールでCommandLine#user属性を使用するように変更
- `sudo`による環境変数リセットで`RAILS_ENV`が渡らない問題を解消
- ginseng-core v1.15.13 (pooza/ginseng-core#476) の新機能に依存

## Test plan
- [ ] ginseng-core PR (pooza/ginseng-core#476) をマージ後、`bundle update ginseng-core`を実行
- [ ] Mastodonツール実行時に`RAILS_ENV`エラーが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)