### PR TITLE
fix: mastodon_media_cleanupのtootctlオプション名を修正

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -75,7 +75,7 @@ mastodon_follow:
 mastodon_media_cleanup:
   commands:
     - media remove-orphans
-    - media remove --remote-headers
+    - media remove --remove-headers
     - preview_cards remove -c 1
 rsync_backup:
   dest: user@host:/path/to/backup

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -19,7 +19,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/THE-POWERNEWS/writersbase-tools
-  version: 1.4.8
+  version: 1.4.9
 ruby:
   bin: /usr/bin/ruby3.3
 hourly: []


### PR DESCRIPTION
## Summary
- `mastodon_media_cleanup`のコマンド設定で、tootctlのオプション`--remote-headers`を正しい`--remove-headers`に修正

## Test plan
- [ ] `bin/wb mastodon_media_cleanup` を実行し、`media remove --remove-headers`が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)