### PR TITLE
fix: FreeBSD 非互換の ionice 参照を削除し、zstd レベルを -3 に引き下げる

### DIFF
--- a/app/lib/writers_base/tool/postgresql_dump_tool.rb
+++ b/app/lib/writers_base/tool/postgresql_dump_tool.rb
@@ -25,13 +25,13 @@ module WritersBase
     def dump(path, params = {})
       logger.info(tool: underscore, db: params[:db], message: 'ダンプ開始')
       command = CommandLine.new([
-        'nice', '-n', '19', 'ionice', '-c3',
+        'nice', '-n', '19',
         'pg_dump',
         '-h', params[:host],
         '-U', params[:user],
         '-p', params[:port],
         '-d', params[:db],
-        :|, 'nice', '-n', '19', 'ionice', '-c3',
+        :|, 'nice', '-n', '19',
         'zstd', "-#{config['/zstd/level']}",
         :>, path
       ])

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -27,7 +27,7 @@ daily: []
 weekly: []
 monthly: []
 zstd:
-  level: 19
+  level: 3
 access_log_compress:
   dir: /var/log/nginx
   days: 1


### PR DESCRIPTION
## 背景

2026-04-11 の shallu (bshockdon) → zugoga (新デルムリン丼) カットオーバー作業中に、PostgresqlDumpTool が FreeBSD 環境で空の zstd ファイル (0 バイト) を生成する不具合を発見した。

調査の結果、以下の 2 つの問題が判明した。

### 問題 1: FreeBSD には ionice コマンドが存在しない

0b9effb で `pg_dump | zstd` の両方に `nice -n 19 ionice -c3` が付与されたが、**FreeBSD には ionice コマンドがない** (Linux 独自)。

shell がパイプラインを解釈する際、左側の `nice -n 19 ionice -c3 pg_dump ...` は `ionice: No such file or directory` で即失敗するため pg_dump は一度も実行されない。右側の `nice -n 19 ionice -c3 zstd ...` も同様に失敗するが、`> path` リダイレクトは **シェルが先に評価してファイルを 0 バイトで作成する** ため、結果として 0 バイトの zstd ファイルが残る。

パイプラインの終了ステータスは最後のコマンド (この場合はリダイレクトでトリガされるシェル) に依存し、0 になる場合があるため、ツールは **success として報告**する。以下のログでその状況が確認できている。

```
{"command":"nice -n 19 ionice -c3 pg_dump -h localhost -U mastodon -p 5432 -d mastodon | nice -n 19 ionice -c3 zstd -19 > /var/backups/db/mastodon/mastodon_2026-04-11.sql.zst","status":0,...}
```

### 問題 2: zstd -19 の CPU 消費が過大

旧 delmulin (goatdeam) では pg_dump + zstd -19 のバッチが高負荷を引き起こし、2026-04-10 に手動で `-3` に引き下げて対応済み (インフラノート参照)。

新サーバー (zugoga / Linode 4GB) への移行の動機のひとつがこの zstd の重さだったため、移行後に再び `-19` で運用するのは本末転倒である。

## 変更内容

### 1. `config/application.yaml`

```diff
 zstd:
-  level: 19
+  level: 3
```

`-19` と `-3` では圧縮時間が数十倍、圧縮率の差は 1〜2 割程度。shallu 規模の DB (24GB) で数時間かかっていたダンプが数分〜十数分程度に収まる想定。

### 2. `app/lib/writers_base/tool/postgresql_dump_tool.rb`

```diff
 command = CommandLine.new([
-  'nice', '-n', '19', 'ionice', '-c3',
+  'nice', '-n', '19',
   'pg_dump',
   ...
-  :|, 'nice', '-n', '19', 'ionice', '-c3',
+  :|, 'nice', '-n', '19',
   'zstd', "-#{config['/zstd/level']}",
   :>, path
 ])
```

`nice -n 19` による CPU 優先度低下は維持する。`ionice` 相当の I/O 優先度制御は FreeBSD では提供されない (`idprio`/`rtprio` は CPU scheduling であり別物) ため、削除する。Linux 環境では若干の退行になるが、本ツールの実際の稼働環境は FreeBSD 系が中心であり、副作用の大きい `ionice` を残すメリットよりも互換性を優先する。

## 影響範囲

- shallu (bshockdon): 本修正で復旧予定。現在 periodic スクリプトを一時無効化中
- zugoga (新デルムリン丼): 本修正で初回正常動作予定
- lbock (curesta) / sweep (daisskey): 旧 ginseng ベースのツールを使用しており、writersbase-tools は無関係

## テスト

- shallu / zugoga で `git pull` 後に periodic スクリプトの実行権を戻し、手動実行で動作確認予定
- 既存の rspec テストは変更していない

## 補足

CommandLine / Open3.capture3 ベースのパイプライン実行では pipefail 相当のチェックが行われず、左側コマンドの失敗が検知されない構造的な問題がある。本 PR では対応しないが、将来的には別 issue で扱うのが望ましい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)