### PR TITLE
fix: tootctl実行前にMastodonのbundle充足を確認する

### DIFF
--- a/app/lib/writers_base/tool/mastodon_follow_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_follow_tool.rb
@@ -37,7 +37,11 @@ module WritersBase
       check.dir = mastodon_dir
       check.exec
       return if check.status.zero?
-      raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
+      raise [
+        'Mastodonのbundleが未充足です。',
+        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
+        "(#{check.stderr.strip})",
+      ].join(' ')
     end
 
     def mastodon_user = config['/mastodon/user']

--- a/app/lib/writers_base/tool/mastodon_follow_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_follow_tool.rb
@@ -24,10 +24,20 @@ module WritersBase
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
       unless test?
+        bundle_check!
         command.exec
         raise command.stderr if command.status.nonzero?
       end
       return command
+    end
+
+    def bundle_check!
+      check = CommandLine.new(['bundle', 'check'])
+      check.user = mastodon_user
+      check.dir = mastodon_dir
+      check.exec
+      return if check.status.zero?
+      raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
     end
 
     def mastodon_user = config['/mastodon/user']

--- a/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
@@ -26,10 +26,20 @@ module WritersBase
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
       unless test?
+        bundle_check!
         command.exec
         raise command.stderr if command.status.nonzero?
       end
       return command
+    end
+
+    def bundle_check!
+      check = CommandLine.new(['bundle', 'check'])
+      check.user = mastodon_user
+      check.dir = mastodon_dir
+      check.exec
+      return if check.status.zero?
+      raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
     end
 
     def mastodon_user = config['/mastodon/user']

--- a/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
@@ -39,7 +39,11 @@ module WritersBase
       check.dir = mastodon_dir
       check.exec
       return if check.status.zero?
-      raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
+      raise [
+        'Mastodonのbundleが未充足です。',
+        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
+        "(#{check.stderr.strip})",
+      ].join(' ')
     end
 
     def mastodon_user = config['/mastodon/user']

--- a/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
@@ -26,10 +26,20 @@ module WritersBase
       command.env = {'RAILS_ENV' => mastodon_rails_env}
       command.dir = mastodon_dir
       unless test?
+        bundle_check!
         command.exec
         raise command.stderr if command.status.nonzero?
       end
       return command
+    end
+
+    def bundle_check!
+      check = CommandLine.new(['bundle', 'check'])
+      check.user = mastodon_user
+      check.dir = mastodon_dir
+      check.exec
+      return if check.status.zero?
+      raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
     end
 
     def mastodon_user = config['/mastodon/user']

--- a/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
@@ -39,7 +39,11 @@ module WritersBase
       check.dir = mastodon_dir
       check.exec
       return if check.status.zero?
-      raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
+      raise [
+        'Mastodonのbundleが未充足です。',
+        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
+        "(#{check.stderr.strip})",
+      ].join(' ')
     end
 
     def mastodon_user = config['/mastodon/user']


### PR DESCRIPTION
## 背景

zugoga（新デルムリン丼）への緊急移転後、Mastodon リポジトリで `bundle install` を忘れていたため、週次の `mastodon_media_cleanup` が失敗していた。`/var/log/writersbase-tools.log` に残ったエラーは:

\`\`\`
bundler: failed to load command: bin/tootctl (bin/tootctl)
.../bundler/source/git.rb:233:in `rescue in load_spec_files':
https://github.com/mastodon/webpush.git (at 9631ac6@9631ac6) is not yet checked out.
Run `bundle install` first. (Bundler::GitError)
\`\`\`

Bundler 内部のスタックトレースだけが残るため、運用者から見て「Mastodon の bundle install が未実行」という核心が一目で分からない。

通常の Mastodon アップグレードは手作業（マージのコンフリクト解決を含むため）で、その手順には bundle install が含まれている。今回はずっと眠らせていた本番環境を急遽投入したという、いつもと違う経緯で bundle install が漏れていた。

## 変更

`mastodon_*` 系ツール（`mastodon_follow_tool` / `mastodon_maintenance_tool` / `mastodon_media_cleanup_tool`）が `tootctl` を起動する直前に `bundle check` を実行し、未充足ならば運用者向けの明確なメッセージで即座に失敗させる。

\`\`\`ruby
def bundle_check!
  check = CommandLine.new(['bundle', 'check'])
  check.user = mastodon_user
  check.dir = mastodon_dir
  check.exec
  return if check.status.zero?
  raise "Mastodonのbundleが未充足です。`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください (#{check.stderr.strip})"
end
\`\`\`

失敗時のメッセージ例（writersbase-tools.log の `error` フィールドに記録される）:

> Mastodonのbundleが未充足です。`cd /home/mastodon/repos/mastodon && sudo -u mastodon bundle install` を実行してください (...)

## 設計判断

- **自動的な `bundle install` は実行しない**: Mastodon の更新は手作業のフローで、自動デプロイ動作は事故の元になるため。本 PR はあくまで「失敗を分かりやすくする保険」
- **`mastodon_*` 系限定**: `postgresql_dump` 等は対象外（Mastodon の bundle に依存しない）
- **3 ファイルに同じ private メソッドを追加（重複）**: 本来は mixin で共通化すべきだが、本 PR の主目的（保険の追加）と切り離して別 PR でリファクタする方針

## 影響範囲

- 適用先: shallu / zugoga（writersbase-tools が動いている Mastodon サーバー）
- lbock は writersbase-tools 未適用のため対象外（将来のキュアスタ！移転時に tools 適用と一緒に整える）

## テスト

- `test?` のとき `bundle_check!` も `command.exec` も呼ばないため、既存テスト（unit/test）は影響を受けない