### PR TITLE
fix: bin/wbでwritersbase-tools自身のbundle未充足を運用者向けに早期失敗

### DIFF
--- a/bin/wb.rb
+++ b/bin/wb.rb
@@ -1,7 +1,16 @@
 #!/usr/bin/env ruby
+require 'bundler'
 $LOAD_PATH.unshift(File.join(File.expand_path('..', __dir__), 'app/lib'))
 
-require 'writers_base'
+begin
+  require 'writers_base'
+rescue Bundler::BundlerError => e
+  root = File.expand_path('..', __dir__)
+  warn 'writersbase-toolsのbundleが未充足です。'
+  warn "`cd #{root} && bundle install` を実行してください。"
+  warn "詳細: #{e.message.lines.first&.strip}"
+  exit 1
+end
 module WritersBase
   raise 'tool undefined' unless name = ARGV.first&.underscore
   puts Tool.create(name).body(ARGV)


### PR DESCRIPTION
## 背景

#35 は Mastodon 側 bundle が未充足な場合の早期失敗を扱うが、**writersbase-tools 自身** の bundle も未充足になり得る（zugoga 緊急投入時に実際に発生）。chubo-core の writersbase_tools クックブックは bundle install を含むため、chef を流せば自動で解消するが、`git pull` だけで済ませた場合に漏れる。

未充足の場合、`bin/wb` は `require 'writers_base'` 内の `require 'bundler/setup'` で `Bundler::BundlerError` を投げ、汎用 `rescue` で bundler 内部メッセージがそのまま流れてくる。運用者から見て「writersbase-tools 自身の bundle install が必要」という核心が一目で分からない。

## 変更

`bin/wb` 冒頭で `require 'bundler'`（Bundler モジュールのみロード、gem 解決はしない）してから `require 'writers_base'` を `Bundler::BundlerError` でガードし、不足時は明示メッセージで早期失敗:

\`\`\`ruby
require 'bundler'
$LOAD_PATH.unshift(File.join(File.expand_path('..', __dir__), 'app/lib'))

begin
  require 'writers_base'
rescue Bundler::BundlerError => e
  root = File.expand_path('..', __dir__)
  warn 'writersbase-toolsのbundleが未充足です。'
  warn "\`cd #{root} && bundle install\` を実行してください。"
  warn "詳細: #{e.message.lines.first&.strip}"
  exit 1
end
\`\`\`

## 失敗時の出力例

\`\`\`
$ bin/wb mastodon_follow
writersbase-toolsのbundleが未充足です。
\`cd /home/mastodon/repos/writersbase-tools && bundle install\` を実行してください。
詳細: ...
\`\`\`

exit code 1 で終了。

## 設計判断

- **自動的な \`bundle install\` は実行しない**: PR #35 と同じ方針。保険のみ提供しデプロイ動作はしない
- **\`require 'bundler'\` は安全**: bundler は Ruby 標準の gem で、メモリにモジュールをロードするだけ。gem 解決は \`bundler/setup\` で初めて起こる
- **\`Bundler::BundlerError\` で catch**: \`Bundler::GemNotFound\` / \`Bundler::GitError\` / \`Bundler::GemfileNotFound\` 等の親クラス。広めに拾うことで取りこぼしを防ぐ

## テスト

- 成功パス: 既存テスト経路（`bundle exec bin/wb <tool>`）に影響なし
- 失敗パス: ローカルで `BUNDLE_GEMFILE=/tmp/nonexistent ruby bin/wb.rb mastodon_follow` を実行し、明示メッセージ + exit 1 を確認済み

## 関連

- THE-POWERNEWS/writersbase-tools#35 — Mastodon 側 bundle の早期失敗（同じ設計方針、対象が異なる）