### PR TITLE
fix: Mastodon tootctl を login shell 経由で実行し rbenv を読み込ませる (#44)

### DIFF
--- a/app/lib/writers_base/mastodon_tootctl.rb
+++ b/app/lib/writers_base/mastodon_tootctl.rb
@@ -1,0 +1,45 @@
+module WritersBase
+  # Mastodon の tootctl 実行を login shell (bash -lc) 経由で行う共通処理。
+  #
+  # writersbase-tools 自体は OS 同梱の Ruby で動かす想定だが、Mastodon は
+  # rbenv 管理の Ruby で動く。cron / periodic の非ログインシェルでは rbenv が
+  # 初期化されず OS の Ruby にフォールバックし、Mastodon の bundle を未充足と
+  # 誤判定する。そこで tootctl と bundle check だけは `bash -lc` を挟んで
+  # mastodon ユーザーの rbenv を読み込ませる。
+  module MastodonTootctl
+    private
+
+    def tootctl_command(args)
+      command = login_command(['bundle', 'exec', 'bin/tootctl', *args])
+      unless test?
+        bundle_check!
+        command.exec
+        raise command.stderr if command.status.nonzero?
+      end
+      return command
+    end
+
+    def bundle_check!
+      check = login_command(['bundle', 'check'])
+      check.exec
+      return if check.status.zero?
+      raise [
+        'Mastodonのbundleが未充足です。',
+        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
+        "(#{check.stderr.strip})",
+      ].join(' ')
+    end
+
+    def login_command(args)
+      command = CommandLine.new(['bash', '-lc', Shellwords.join(args)])
+      command.user = mastodon_user
+      command.env = {'RAILS_ENV' => mastodon_rails_env}
+      command.dir = mastodon_dir
+      return command
+    end
+
+    def mastodon_user = config['/mastodon/user']
+    def mastodon_rails_env = config['/mastodon/rails_env']
+    def mastodon_dir = config['/mastodon/dir']
+  end
+end

--- a/app/lib/writers_base/tool/mastodon_follow_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_follow_tool.rb
@@ -1,5 +1,7 @@
 module WritersBase
   class MastodonFollowTool < Tool
+    include MastodonTootctl
+
     def exec(args = {})
       result = {success: [], failure: []}
       logger.info(tool: underscore, account:, message: 'フォロー実行開始')
@@ -15,37 +17,5 @@ module WritersBase
     def description
       return '全ユーザーに指定アカウントを強制フォローさせます。'
     end
-
-    private
-
-    def tootctl_command(args)
-      command = CommandLine.new(['bundle', 'exec', 'bin/tootctl', *args])
-      command.user = mastodon_user
-      command.env = {'RAILS_ENV' => mastodon_rails_env}
-      command.dir = mastodon_dir
-      unless test?
-        bundle_check!
-        command.exec
-        raise command.stderr if command.status.nonzero?
-      end
-      return command
-    end
-
-    def bundle_check!
-      check = CommandLine.new(['bundle', 'check'])
-      check.user = mastodon_user
-      check.dir = mastodon_dir
-      check.exec
-      return if check.status.zero?
-      raise [
-        'Mastodonのbundleが未充足です。',
-        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
-        "(#{check.stderr.strip})",
-      ].join(' ')
-    end
-
-    def mastodon_user = config['/mastodon/user']
-    def mastodon_rails_env = config['/mastodon/rails_env']
-    def mastodon_dir = config['/mastodon/dir']
   end
 end

--- a/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_maintenance_tool.rb
@@ -1,5 +1,7 @@
 module WritersBase
   class MastodonMaintenanceTool < Tool
+    include MastodonTootctl
+
     def exec(args = {})
       result = {success: [], failure: []}
       commands.each do |cmd|
@@ -17,37 +19,5 @@ module WritersBase
     def description
       return 'Mastodonのメンテナンスコマンドを実行します。'
     end
-
-    private
-
-    def tootctl_command(args)
-      command = CommandLine.new(['bundle', 'exec', 'bin/tootctl', *args])
-      command.user = mastodon_user
-      command.env = {'RAILS_ENV' => mastodon_rails_env}
-      command.dir = mastodon_dir
-      unless test?
-        bundle_check!
-        command.exec
-        raise command.stderr if command.status.nonzero?
-      end
-      return command
-    end
-
-    def bundle_check!
-      check = CommandLine.new(['bundle', 'check'])
-      check.user = mastodon_user
-      check.dir = mastodon_dir
-      check.exec
-      return if check.status.zero?
-      raise [
-        'Mastodonのbundleが未充足です。',
-        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
-        "(#{check.stderr.strip})",
-      ].join(' ')
-    end
-
-    def mastodon_user = config['/mastodon/user']
-    def mastodon_rails_env = config['/mastodon/rails_env']
-    def mastodon_dir = config['/mastodon/dir']
   end
 end

--- a/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
+++ b/app/lib/writers_base/tool/mastodon_media_cleanup_tool.rb
@@ -1,5 +1,7 @@
 module WritersBase
   class MastodonMediaCleanupTool < Tool
+    include MastodonTootctl
+
     def exec(args = {})
       result = {success: [], failure: []}
       commands.each do |cmd|
@@ -17,37 +19,5 @@ module WritersBase
     def description
       return 'Mastodonの古いメディアファイルを削除します。'
     end
-
-    private
-
-    def tootctl_command(args)
-      command = CommandLine.new(['bundle', 'exec', 'bin/tootctl', *args])
-      command.user = mastodon_user
-      command.env = {'RAILS_ENV' => mastodon_rails_env}
-      command.dir = mastodon_dir
-      unless test?
-        bundle_check!
-        command.exec
-        raise command.stderr if command.status.nonzero?
-      end
-      return command
-    end
-
-    def bundle_check!
-      check = CommandLine.new(['bundle', 'check'])
-      check.user = mastodon_user
-      check.dir = mastodon_dir
-      check.exec
-      return if check.status.zero?
-      raise [
-        'Mastodonのbundleが未充足です。',
-        "`cd #{mastodon_dir} && sudo -u #{mastodon_user} bundle install` を実行してください",
-        "(#{check.stderr.strip})",
-      ].join(' ')
-    end
-
-    def mastodon_user = config['/mastodon/user']
-    def mastodon_rails_env = config['/mastodon/rails_env']
-    def mastodon_dir = config['/mastodon/dir']
   end
 end

--- a/test/mastodon_maintenance_tool_test.rb
+++ b/test/mastodon_maintenance_tool_test.rb
@@ -1,0 +1,22 @@
+module WritersBase
+  class MastodonMaintenanceToolTest < TestCase
+    def setup
+      @tool = Tool.create('mastodon_maintenance')
+    end
+
+    def test_execute
+      assert_kind_of(Array, @tool.exec[:success])
+      assert_kind_of(Array, @tool.exec[:failure])
+    end
+
+    def test_description
+      assert_kind_of(String, @tool.description)
+    end
+
+    def test_login_shell
+      command = @tool.send(:login_command, ['bundle', 'check'])
+
+      assert_match(/\Abash -lc /, command.to_s)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

close #44

cron / periodic は非ログインシェルで動くため rbenv が初期化されず、`sudo -u mastodon sh -c 'bundle …'` が OS 同梱の Ruby (3.3.10) にフォールバックする。Mastodon 4.6 化で Ruby が 3系→4系 (4.0.5) に上がった結果、native 拡張の ABI 差で bundle が未充足と誤判定され、`bundle_check!` が raise して tootctl（週次/日次/時次の maintenance・media_cleanup・follow）が全て中断していた。

tootctl と bundle check を `bash -lc`（login shell）経由で実行し、mastodon ユーザーの rbenv を読み込ませる。tools 本体は従来どおり OS Ruby で動く（設計意図を維持）。

## 変更点

- `app/lib/writers_base/mastodon_tootctl.rb` を新設し、3ツールで重複していた `tootctl_command` / `bundle_check!` / config アクセサを集約。実行を `bash -lc` 経由に変更
- `mastodon_maintenance` / `mastodon_media_cleanup` / `mastodon_follow` を同モジュール `include` に置換
- login shell 化を検証するテストを追加

## 動作確認

- 実機 (zugoga) で `sudo -u mastodon sh -c '… bundle check'` は Ruby 3.3.10 / missing、`bash -lc` 経由は Ruby 4.0.5 / satisfied を確認
- CommandLine が生成する入れ子 `sudo … sh -c 'bash -lc "…"'` でも Ruby 4.0.5 / satisfied、`bash` は sudo PATH で解決
- `bundle exec rubocop`（変更ファイル）offense なし、`bin/test.rb mastodon_maintenance_tool` pass